### PR TITLE
🐛 Fix typo in DeviceSimulation.jl

### DIFF
--- a/src/DeviceSimulation.jl
+++ b/src/DeviceSimulation.jl
@@ -1,6 +1,6 @@
 module DeviceSimulation
 
-export ħ, Electron, velocity, energy, poisson_equation!, ScalarField, VectorField, gradiend
+export ħ, Electron, velocity, energy, poisson_equation!, ScalarField, VectorField, gradient
 
 include("coordinate_utils.jl")
 include("electron.jl")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the variable name from `gradiend` to `gradient` in the DeviceSimulation module, ensuring proper functionality and accessibility of the gradient identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->